### PR TITLE
Update WebTwain_Acquire-v16.1.1.md

### DIFF
--- a/info/api/WebTwain_Acquire-v16.1.1.md
+++ b/info/api/WebTwain_Acquire-v16.1.1.md
@@ -2124,7 +2124,7 @@ DWObject.RegisterEvent('OnPostAllTransfers',
  * This event is triggered after each page has been scanned and transferred.
  * @argument outputInfo Detailed information about the image that just got transferred.
  */ 
-RegisterEvent('OnPostTransfer',function(outputInfo: OutputInfo) {});
+RegisterEvent('OnPostTransfer',function() {});
 ```
 
 **Example**


### PR DESCRIPTION
remove outputInfo from OnPostTransfer as it is only accessible in OnPostTransferAsync