### PR TITLE
Refactor installer links to OS tabs and add version guidance

### DIFF
--- a/_articles/faq/failed-to-load-resource.md
+++ b/_articles/faq/failed-to-load-resource.md
@@ -7,7 +7,7 @@ keywords: Dynamic Web TWAIN, Error Message, Failed to load resource, CERT INVALI
 breadcrumbText: Error Message - Failed to load resource
 description: Error Message - Failed to load resource
 date: 2021-12-01 17:04:03 +0800
-last_modified: 2025-11-05 15:23:24 +0800
+last_modified: 2026-03-25 12:48:00 -0700
 ---
 
 # Error Troubleshooting
@@ -26,9 +26,6 @@ In this case, we provide a domain, "local.dynamsoft.com", which points to "127.0
 
 > ___Please note:___ _all official certificates issued by 3rd party come with an expiry date - generally one year. This means that each year the certificate will need to be updated if local.dynamsoft.com is used._
 
-<!-- 2. Your own domain certificate expired. -->
-
-<!-- In this case, if you are trying to access an application that integrates a version of Dynamic Web TWAIN V15.3 ~ V17.2.5, you will get the error. Because the old "local.dynamsoft.com" certificate expired on <font color=red>January 9th, 2023</font>.  -->
 
 ### Resolution
 
@@ -39,90 +36,57 @@ In this case, we provide a domain, "local.dynamsoft.com", which points to "127.0
 
   If you have to use "local.dynamsoft.com", the following methods can be taken:
 
-  - Method 1.Use the following links to download and install the new Dynamic Web TWAIN Service Installer.
-    - For Windows
-        > Choose between Admin (requires admin privileges) or Personal (for individual users).
-        - Version 19.2
-            - [Windows Installer (Admin)](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.2/DynamicWebTWAINServiceSetup.msi)
-            - [Windows Installer (Personal)](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.2/DynamicWebTWAINServiceSetup.exe)
-        - Version 18
-            - [Windows Installer (Admin)](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.2/DynamsoftServiceSetup.msi)
-            - [Windows Installer (Personal)](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.2/DynamsoftServiceSetup.exe)
-    - For macOS
-        > Use the installer matching your SDK version.
-        - [macOS Installer v19.2](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.2/DynamicWebTWAINServiceSetup.pkg)
-        - [macOS Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.2/DynamsoftServiceSetup.pkg)
-    - For Linux
-        > Select the installer format based on your distribution type.
-        - RPM Packages (Red Hat, Fedora, CentOS, etc.)
-            - [Linux RPM Installer v19.2](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.2/DynamicWebTWAINServiceSetup.rpm)
-            - [Linux RPM Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.2/DynamsoftServiceSetup.rpm)
-         - DEB Packages (Ubuntu, Debian, etc.)
-            - [Linux DEB Installer v19.2](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.2/DynamicWebTWAINServiceSetup.deb)
-            - [Linux DEB Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.2/DynamsoftServiceSetup.deb)
-         - ARM64 Architecture
-            - [Linux ARM64 DEB Installer v19.2](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.2/DynamicWebTWAINServiceSetup-arm64.deb)
-            - [Linux ARM64 DEB Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.2/DynamsoftServiceSetup-arm64.deb)
-         - MIPS Architecture
-            - [Linux MIPS DEB Installer v19.2](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.2/DynamicWebTWAINServiceSetup-mips64el.deb)
-            - [Linux MIPS DEB Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.2/DynamsoftServiceSetup-mips64el.deb)
+  - Method 1. Use the following links to download and install the Dynamic Web TWAIN Service Installer.
+    > Note: Dynamic Web TWAIN Service installers are backward-compatible within the same major version. Please identify the major SDK version you are using first, then download the corresponding installer (for example, 19.x SDK uses v19 installers, 18.x SDK uses v18 installers). If you are unsure about your SDK version, follow [How do I know which SDK version I am using?](/_articles/faq/find-SDK-version.md).
+
+    <div class="multi-panel-switching-prefix"></div>
+
+    - Windows
+    - macOS
+    - Linux
+
+    <div class="multi-panel-start"></div>
+
+    > Choose between Admin (requires admin privileges) or Personal (for individual users).
+    - Version 19
+      - [Windows Installer (Admin)](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.3.2/DynamicWebTWAINServiceSetup.msi)
+      - [Windows Installer (Personal)](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.3.2/DynamicWebTWAINServiceSetup.exe)
+    - Version 18
+      - [Windows Installer (Admin)](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.4/DynamsoftServiceSetup.msi)
+      - [Windows Installer (Personal)](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.4/DynamsoftServiceSetup.exe)
+
+    <div class="multi-panel-end"></div>
+
+    <div class="multi-panel-start"></div>
+
+    > Use the installer matching your SDK version.
+    - [macOS Installer v19](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.3.2/DynamicWebTWAINServiceSetup.pkg)
+    - [macOS Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.4/DynamsoftServiceSetup.pkg)
+
+    <div class="multi-panel-end"></div>
+
+    <div class="multi-panel-start"></div>
+
+    > Select the installer format based on your distribution type.
+    - RPM Packages (Red Hat, Fedora, CentOS, etc.)
+      - [Linux RPM Installer v19](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.3.2/DynamicWebTWAINServiceSetup.rpm)
+      - [Linux RPM Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.4/DynamsoftServiceSetup.rpm)
+    - DEB Packages (Ubuntu, Debian, etc.)
+      - [Linux DEB Installer v19](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.3.2/DynamicWebTWAINServiceSetup.deb)
+      - [Linux DEB Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.4/DynamsoftServiceSetup.deb)
+    - ARM64 Architecture
+      - [Linux ARM64 DEB Installer v19](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.3.2/DynamicWebTWAINServiceSetup-arm64.deb)
+      - [Linux ARM64 DEB Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.4/DynamsoftServiceSetup-arm64.deb)
+    - MIPS Architecture
+      - [Linux MIPS DEB Installer v19](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/19.3.2/DynamicWebTWAINServiceSetup-mips64el.deb)
+      - [Linux MIPS DEB Installer v18](https://download2.dynamsoft.com/Demo/DWT/Resources/dist/18.5.4/DynamsoftServiceSetup-mips64el.deb)
+
+    <div class="multi-panel-end"></div>
+
+    <div class="multi-panel-switching-end"></div>
 
   - Method 2. Click <a href="https://demo.dynamsoft.com/DWT/Resources/dist/cert.zip" target="_blank">here</a> to download the new certificate and use the new server.pem.ldsc & server_key.pem.ldsc to replace the old one in the `cert` folder under the service's [installation folder](/_articles/extended-usage/dynamsoft-service-configuration.md#installation-folder). Then restart Dynamic Web TWAIN Service.
 
   - Method 3. [Contact Dynamsoft](/_articles/about/getsupport.md){:target="_blank"} for a new service installer for client-side. Please specify the exact service version build number found from the version your client currently has installed.
 
   - Method 4. You can also generate the certificate by yourself. Check out this [post](/_articles/faq/change-dynamsoft-service-certificate.md).
-
-<!--
-
-        - Method 4 (**<u>Convenience but not recommend</u>**). For v17.2 or higher versions, you can use the new API [UpdateCert](/_articles/info/api/Dynamsoft_WebTwainEnv.md#updatecert){:target="_blank"} to automatically update the client side certificate before it expires. **Please go to dynamsoft.webtwain.install.js file in the Resource Folder and search the keyword "OnSSLCertInfo"**, add the following lines of code:
-            ```javascript
-            Dynamsoft.OnSSLCertInfo = function (sslExpiredDate) {
-                if ((sslExpiredDate - new Date()) / 86400000 < 15) { // Automatically updates 15 days before expiration
-                    Dynamsoft.DWT.UpdateCert(
-                        "https://demo.dynamsoft.com/DWT/Resources/dist/cert.zip", //You may use your own URL to where the new certificate is placed.
-                        function () {
-                            //Success callback
-                        },
-                        function (errorCode, errorString) {
-                            console.log(errorString);
-                        }
-                    );
-                }
-            };
-            ```
-            ***Please be aware that the download may not work properly in all environments due to your company's security policy.***
-
-
- 1) Go to service directory, and find _DSConfiguration.ini_.  
-<ul>
-   <li>Windows: C:\Windows\SysWOW64\Dynamsoft\DynamsoftService or C:\Windows\SysWOW64\Dynamsoft\DynamsoftServicex64_(version)</li>   
-   <li>macOS: Go > Applications > Dynamsoft > DynamsoftService > {installed version No.}</li>   
-   <li>Linux: opt/dynamsoft/DynamsoftService</li>
-</ul>   
-   
- then add the following code lines in DSConfiguration.ini  
-
-```javascript
-//if you prefer to use your own valid certificate, change the local.dynamsoftwebtwain.com to your own address. As well as cert_name and key_name. 
-[local.dynamsoftwebtwain.com]  
-cert_name=server.pem.ldsc       
-key_name=server_key.pem.ldsc  
-```
-
- 2) Click <a href="https://tst.dynamsoft.com/public/download/dwt/newcert/newcert.zip" target="_blank">here</a> to download the new certificate and use the new server.pem.ldsc & server_key.pem.ldsc to replace the old one under [cert](/_articles/extended-usage/dynamsoft-service-configuration.md#for-the-service){:target="_blank"} folder.
-
-If you use your own certificate, put your own cert and key under the cert folder. 
-
-Note: the new certificate from Dynamsoft will expire on September 23th, 2022. This means you will need to update the certificate again after this certificate expires.
-<br>
-
- 3) Call the following line in Resources/dynamsoft.webtwain.config.js to use the new certificate. 
-   ```javascript 
-  // V15.3~16.2 uses
-  Dynamsoft.WebTwainEnv.Host = 'local.dynamsoftwebtwain.com';
- 
-  // V17.0+ uses
-  Dynamsoft.DWT.Host = 'local.dynamsoftwebtwain.com';
-   ```
--->

--- a/_articles/faq/failed-to-load-resource.md
+++ b/_articles/faq/failed-to-load-resource.md
@@ -24,7 +24,8 @@ By default, "127.0.0.1" is used for service connection. "127.0.0.1" uses a self-
 
 In this case, we provide a domain, "local.dynamsoft.com", which points to "127.0.0.1". It has a VeriSign’ed certificate that has an expiry date. The most recent expired "local.dynamsoft.com" certificate expired on <font color=red>2025 November 20th</font>, and the latest certificate will expire on <font color=red>2026 November 21st</font>.
 
-> ___Please note:___ _all official certificates issued by 3rd party come with an expiry date - generally one year. This means that each year the certificate will need to be updated if local.dynamsoft.com is used._
+> [!NOTE]
+> All official third-party certificates come with an expiry date (generally one year). If `local.dynamsoft.com` is used, the certificate needs to be updated each year.
 
 
 ### Resolution
@@ -32,12 +33,16 @@ In this case, we provide a domain, "local.dynamsoft.com", which points to "127.0
 - **No High Level Security Requirement**:
   Set back to self-signed certificate "127.0.0.1" by comment the line `Dynamsoft.WebTwainEnv.Host = "local.dynamsoft.com"` or `Dynamsoft.DWT.Host="local.dynamsoft.com"` out. No need to worry about the expiry date of the certificate anymore.
 
-- **High Level Security Requirement (<font color=red>Please note: you need to replace the certificate annually due to expiration</font>)**
+- **High Level Security Requirement**
+
+  > [!WARNING]
+  > If you use `local.dynamsoft.com`, replace the certificate annually due to expiration.
 
   If you have to use "local.dynamsoft.com", the following methods can be taken:
 
   - Method 1. Use the following links to download and install the Dynamic Web TWAIN Service Installer.
-    > Note: Dynamic Web TWAIN Service installers are backward-compatible within the same major version. Please identify the major SDK version you are using first, then download the corresponding installer (for example, 19.x SDK uses v19 installers, 18.x SDK uses v18 installers). If you are unsure about your SDK version, follow [How do I know which SDK version I am using?](/_articles/faq/find-SDK-version.md).
+    > [!IMPORTANT]
+    > Dynamic Web TWAIN Service installers are backward-compatible within the same major version. Identify the major SDK version first, then download the corresponding installer (for example, 19.x SDK uses v19 installers, 18.x SDK uses v18 installers). If you are unsure about your SDK version, follow [How do I know which SDK version I am using?](/_articles/faq/find-SDK-version.md).
 
     <div class="multi-panel-switching-prefix"></div>
 


### PR DESCRIPTION
This pull request updates the troubleshooting documentation for the "Failed to load resource" error in Dynamic Web TWAIN, focusing on clarifying and modernizing the instructions for updating certificates and service installers. The main improvements include clearer instructions, updated download links, and a more user-friendly, organized presentation for different operating systems and architectures.

**Documentation and usability improvements:**

* Added a multi-panel, step-by-step guide for downloading and installing the correct Dynamic Web TWAIN Service Installer, with clear separation for Windows, macOS, and Linux platforms, and explicit instructions to match the installer to the SDK version in use.
* Updated all installer download links to the latest patch versions (e.g., v19.3.2 and v18.5.4) for each OS and architecture, ensuring users receive the most recent and secure version.
* Added notes and references to help users identify their SDK version and choose the correct installer, improving the troubleshooting workflow.

**Content cleanup and maintenance:**

* Removed outdated or commented-out instructions and legacy certificate update methods, streamlining the document for clarity and relevance. [[1]](diffhunk://#diff-47b54783e5522ee786ba2470df90fe407f321620e8fe9c87a1a4331e2a217a70L29-L31) [[2]](diffhunk://#diff-47b54783e5522ee786ba2470df90fe407f321620e8fe9c87a1a4331e2a217a70L42-L128)
* Updated the `last_modified` metadata to reflect the latest documentation update.