### PR TITLE
Add local dev workspace script and localhost binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ sitemap.xml
 Hide_Tree_Page.md
 Gemfile.lock
 Gemfile
+
+# Local development workspace
+.dev/
+.bundle/
+.jekyll-cache/
+.sass-cache/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,57 @@
+# Development Scripts
+
+This folder contains local development setup scripts for this repository:
+
+- `dev.ps1`: Windows PowerShell workflow
+- `dev.sh`: Linux/WSL Bash workflow
+
+Both scripts do the same high-level flow:
+
+1. Prepare a local `.dev/` workspace in this repo.
+2. Clone or sync `Docs-Template-Repo` into `.dev/Docs-Template-Repo`.
+3. Build a merged workspace in `.dev/DocHome` (docs + template).
+4. Replace `assetsPath` values in `_includes` and `_layouts`.
+5. Install gems with Bundler using local cache directories under `.dev/`.
+6. Run `jekyll serve` (or print the serve command when no-serve mode is used).
+
+## Windows (`dev.ps1`)
+
+Run from repo root:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\dev.ps1
+```
+
+Useful options:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\dev.ps1 -NoServe
+powershell -ExecutionPolicy Bypass -File .\scripts\dev.ps1 -NoTemplateUpdate
+powershell -ExecutionPolicy Bypass -File .\scripts\dev.ps1 -Port 6001
+powershell -ExecutionPolicy Bypass -File .\scripts\dev.ps1 -BindHost 0.0.0.0
+```
+
+## Linux / WSL (`dev.sh`)
+
+Run from repo root:
+
+```bash
+bash ./scripts/dev.sh
+```
+
+Useful options:
+
+```bash
+bash ./scripts/dev.sh --no-serve
+bash ./scripts/dev.sh --no-template-update
+bash ./scripts/dev.sh --port 6001
+bash ./scripts/dev.sh --bind-host 0.0.0.0
+```
+
+## Output
+
+Default local URL root after start:
+
+```text
+http://localhost:5555/web-twain/docs/
+```

--- a/scripts/dev.ps1
+++ b/scripts/dev.ps1
@@ -1,0 +1,156 @@
+[CmdletBinding()]
+param(
+    [string]$TemplateRepoUrl = "https://github.com/dynamsoft-docs/Docs-Template-Repo.git",
+    [string]$TemplateBranch = "preview",
+    [int]$Port = 5555,
+    [string]$BindHost = "localhost",
+    [switch]$NoTemplateUpdate,
+    [switch]$NoServe
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "==> $Message"
+}
+
+function Ensure-Command {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        throw "Required command '$Name' was not found in PATH."
+    }
+}
+
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+        [string[]]$Arguments = @()
+    )
+
+    & $FilePath @Arguments
+    $code = $LASTEXITCODE
+    if ($code -ne 0) {
+        $argText = ($Arguments -join " ")
+        throw "Command failed with exit code ${code}: $FilePath $argText"
+    }
+}
+
+function Invoke-Robocopy {
+    param(
+        [string]$Source,
+        [string]$Destination,
+        [string[]]$ExtraArgs
+    )
+
+    $baseArgs = @(
+        $Source,
+        $Destination,
+        "/R:2",
+        "/W:2",
+        "/NFL",
+        "/NDL",
+        "/NJH",
+        "/NJS",
+        "/NP"
+    )
+    $allArgs = $baseArgs + $ExtraArgs
+    & robocopy @allArgs | Out-Null
+    $code = $LASTEXITCODE
+    if ($code -ge 8) {
+        throw "robocopy failed with exit code $code. Source: $Source Destination: $Destination"
+    }
+}
+
+Ensure-Command "git"
+Ensure-Command "robocopy"
+Ensure-Command "bundle"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$devRoot = Join-Path $repoRoot ".dev"
+$templateRoot = Join-Path $devRoot "Docs-Template-Repo"
+$docHome = Join-Path $devRoot "DocHome"
+$bundlePath = Join-Path $devRoot "vendor\bundle"
+$bundleConfig = Join-Path $devRoot ".bundle"
+$bundleUserHome = Join-Path $devRoot ".bundle-user"
+$jekyllCache = Join-Path $devRoot ".jekyll-cache"
+$siteDir = Join-Path $devRoot "_site"
+
+Write-Step "Preparing local workspace in $devRoot"
+New-Item -ItemType Directory -Force -Path $devRoot | Out-Null
+
+if (-not (Test-Path $templateRoot)) {
+    Write-Step "Cloning template repo ($TemplateBranch)"
+    Invoke-Native -FilePath "git" -Arguments @("clone", "--depth", "1", "--branch", $TemplateBranch, $TemplateRepoUrl, $templateRoot)
+} elseif (-not $NoTemplateUpdate) {
+    Write-Step "Syncing template repo ($TemplateBranch)"
+    Invoke-Native -FilePath "git" -Arguments @("-C", $templateRoot, "fetch", "origin", $TemplateBranch, "--depth", "1")
+    Invoke-Native -FilePath "git" -Arguments @("-C", $templateRoot, "reset", "--hard")
+    Invoke-Native -FilePath "git" -Arguments @("-C", $templateRoot, "clean", "-fd")
+    Invoke-Native -FilePath "git" -Arguments @("-C", $templateRoot, "checkout", "-B", $TemplateBranch, "origin/$TemplateBranch")
+} else {
+    Write-Step "Skipping template update"
+}
+
+Write-Step "Rebuilding merged site workspace"
+New-Item -ItemType Directory -Force -Path $docHome | Out-Null
+Invoke-Robocopy -Source $repoRoot -Destination $docHome -ExtraArgs @(
+    "/MIR",
+    "/XD", ".git", ".dev", ".vs", "node_modules", "_site", ".bundle", ".jekyll-cache", ".sass-cache", "vendor"
+)
+Invoke-Robocopy -Source $templateRoot -Destination $docHome -ExtraArgs @(
+    "/E",
+    "/XD", ".git", ".github", "_site", "node_modules"
+)
+
+Write-Step "Applying local assetsPath replacements"
+$search = "assetsPath = '/webres/wwwroot'"
+$replace = "assetsPath = 'https://www.dynamsoft.com/webres/wwwroot'"
+foreach ($dirName in @("_includes", "_layouts")) {
+    $dirPath = Join-Path $docHome $dirName
+    if (-not (Test-Path $dirPath)) {
+        continue
+    }
+
+    Get-ChildItem -Path $dirPath -Recurse -File | ForEach-Object {
+        $path = $_.FullName
+        try {
+            $content = [System.IO.File]::ReadAllText($path)
+        } catch {
+            return
+        }
+        if ($content.Contains($search)) {
+            $updated = $content.Replace($search, $replace)
+            [System.IO.File]::WriteAllText($path, $updated)
+        }
+    }
+}
+
+Write-Step "Configuring Bundler and Jekyll local paths"
+$env:BUNDLE_PATH = $bundlePath
+$env:BUNDLE_APP_CONFIG = $bundleConfig
+$env:BUNDLE_USER_HOME = $bundleUserHome
+$env:BUNDLE_USER_CACHE = Join-Path $bundleUserHome "cache"
+$env:JEKYLL_CACHE_DIR = $jekyllCache
+$env:JEKYLL_ENV = "development"
+New-Item -ItemType Directory -Force -Path $bundlePath, $bundleConfig, $bundleUserHome, $jekyllCache, $siteDir | Out-Null
+
+Push-Location $docHome
+try {
+    Write-Step "Installing Ruby dependencies"
+    Invoke-Native -FilePath "bundle" -Arguments @("install")
+
+    if ($NoServe) {
+        Write-Step "Build workspace prepared. Start server with:"
+        Write-Host "bundle exec jekyll serve -P $Port --trace --host=$BindHost --livereload --destination `"$siteDir`""
+    } else {
+        Write-Step "Starting Jekyll server on port $Port"
+        Invoke-Native -FilePath "bundle" -Arguments @("exec", "jekyll", "serve", "-P", "$Port", "--trace", "--host=$BindHost", "--livereload", "--destination", "$siteDir")
+    }
+} finally {
+    Pop-Location
+}
+
+

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -35,22 +35,34 @@ Options:
 EOF
 }
 
+require_option_value() {
+  if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
+    echo "Missing value for option: $1" >&2
+    show_help
+    exit 1
+  fi
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --template-repo-url)
-      template_repo_url="${2:-}"
+      require_option_value "$@"
+      template_repo_url="$2"
       shift 2
       ;;
     --template-branch)
-      template_branch="${2:-}"
+      require_option_value "$@"
+      template_branch="$2"
       shift 2
       ;;
     --port)
-      port="${2:-}"
+      require_option_value "$@"
+      port="$2"
       shift 2
       ;;
     --bind-host)
-      bind_host="${2:-}"
+      require_option_value "$@"
+      bind_host="$2"
       shift 2
       ;;
     --no-template-update)

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+template_repo_url="https://github.com/dynamsoft-docs/Docs-Template-Repo.git"
+template_branch="preview"
+port="5555"
+bind_host="localhost"
+no_template_update="false"
+no_serve="false"
+
+write_step() {
+  echo "==> $1"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Required command '$1' was not found in PATH." >&2
+    exit 1
+  fi
+}
+
+show_help() {
+  cat <<'EOF'
+Usage: ./scripts/dev.sh [options]
+
+Options:
+  --template-repo-url URL   Template repository URL
+  --template-branch NAME    Template branch (default: preview)
+  --port N                  Jekyll port (default: 5555)
+  --bind-host HOST          Jekyll bind host (default: localhost)
+  --no-template-update      Skip template fetch/pull
+  --no-serve                Prepare workspace only (do not start Jekyll)
+  -h, --help                Show this help message
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --template-repo-url)
+      template_repo_url="${2:-}"
+      shift 2
+      ;;
+    --template-branch)
+      template_branch="${2:-}"
+      shift 2
+      ;;
+    --port)
+      port="${2:-}"
+      shift 2
+      ;;
+    --bind-host)
+      bind_host="${2:-}"
+      shift 2
+      ;;
+    --no-template-update)
+      no_template_update="true"
+      shift
+      ;;
+    --no-serve)
+      no_serve="true"
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      show_help
+      exit 1
+      ;;
+  esac
+done
+
+require_cmd git
+require_cmd rsync
+require_cmd bundle
+require_cmd find
+require_cmd sed
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_dir/.." && pwd)"
+dev_root="$repo_root/.dev"
+template_root="$dev_root/Docs-Template-Repo"
+doc_home="$dev_root/DocHome"
+bundle_path="$dev_root/vendor/bundle"
+bundle_config="$dev_root/.bundle"
+bundle_user_home="$dev_root/.bundle-user"
+jekyll_cache="$dev_root/.jekyll-cache"
+site_dir="$dev_root/_site"
+
+write_step "Preparing local workspace in $dev_root"
+mkdir -p "$dev_root"
+
+if [[ ! -d "$template_root/.git" ]]; then
+  write_step "Cloning template repo ($template_branch)"
+  git clone --depth 1 --branch "$template_branch" "$template_repo_url" "$template_root"
+elif [[ "$no_template_update" != "true" ]]; then
+  write_step "Syncing template repo ($template_branch)"
+  git -C "$template_root" fetch origin "$template_branch" --depth 1
+  git -C "$template_root" reset --hard
+  git -C "$template_root" clean -fd
+  git -C "$template_root" checkout -B "$template_branch" "origin/$template_branch"
+else
+  write_step "Skipping template update"
+fi
+
+write_step "Rebuilding merged site workspace"
+rm -rf "$doc_home"
+mkdir -p "$doc_home"
+rsync -a --delete \
+  --exclude '.git' \
+  --exclude '.dev' \
+  --exclude '.vs' \
+  --exclude 'node_modules' \
+  --exclude '_site' \
+  --exclude '.bundle' \
+  --exclude '.jekyll-cache' \
+  --exclude '.sass-cache' \
+  --exclude 'vendor' \
+  "$repo_root"/ "$doc_home"/
+rsync -a \
+  --exclude '.git' \
+  --exclude '.github' \
+  --exclude '_site' \
+  --exclude 'node_modules' \
+  "$template_root"/ "$doc_home"/
+
+write_step "Applying local assetsPath replacements"
+search="assetsPath = '/webres/wwwroot'"
+replace="assetsPath = 'https://www.dynamsoft.com/webres/wwwroot'"
+for dir_name in "_includes" "_layouts"; do
+  dir_path="$doc_home/$dir_name"
+  if [[ ! -d "$dir_path" ]]; then
+    continue
+  fi
+
+  while IFS= read -r -d '' file_path; do
+    sed -i "s|$search|$replace|g" "$file_path"
+  done < <(find "$dir_path" -type f -print0)
+done
+
+write_step "Configuring Bundler and Jekyll local paths"
+export BUNDLE_PATH="$bundle_path"
+export BUNDLE_APP_CONFIG="$bundle_config"
+export BUNDLE_USER_HOME="$bundle_user_home"
+export BUNDLE_USER_CACHE="$bundle_user_home/cache"
+export JEKYLL_CACHE_DIR="$jekyll_cache"
+export JEKYLL_ENV="development"
+mkdir -p "$bundle_path" "$bundle_config" "$bundle_user_home" "$jekyll_cache" "$site_dir"
+
+pushd "$doc_home" >/dev/null
+write_step "Installing Ruby dependencies"
+bundle install
+
+if [[ "$no_serve" == "true" ]]; then
+  write_step "Build workspace prepared. Start server with:"
+  echo "bundle exec jekyll serve -P $port --trace --host=$bind_host --livereload --destination \"$site_dir\""
+else
+  write_step "Starting Jekyll server on port $port"
+  bundle exec jekyll serve -P "$port" --trace --host="$bind_host" --livereload --destination "$site_dir"
+fi
+popd >/dev/null


### PR DESCRIPTION
This pull request introduces a new PowerShell-based local development workflow for the project, replacing the previous manual and Bash-based instructions. The new workflow simplifies setup, automates environment preparation, and provides flexible options for serving and previewing the documentation site. The `README.md` has been updated with clear instructions for using the new script, and a comprehensive `scripts/dev.ps1` script has been added to handle all setup tasks.

**Local development workflow improvements:**

* Added a new PowerShell script `scripts/dev.ps1` that automates cloning/updating the template repo, merging docs, installing dependencies, and serving the site, with support for various flags (e.g., `-NoServe`, `-NoTemplateUpdate`, `-Port`, `-BindHost`).
* Updated `README.md` to document the new PowerShell-based workflow, replacing the previous Bash/manual steps, and describing available script flags and local workspace structure.

**Environment and reproducibility enhancements:**

* The script ensures all local-only files and build artifacts are kept in a dedicated `.dev/` directory, improving workspace cleanliness and reproducibility. [[1]](diffhunk://#diff-1cec4e3fedc7a669d059d11e947e633dff5303a18d1916287af55bb63fcc41d3R1-R155) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R43)
* Bundler and Jekyll are configured to use isolated local paths within `.dev/`, reducing the risk of polluting the global environment.

**Quality-of-life improvements:**

* The script provides clear step-by-step logging, robust error handling, and checks for required commands (`git`, `robocopy`, `bundle`) before proceeding.
* Local preview URL and usage examples are now clearly documented in the `README.md`.