### PR TITLE
docs: link AI nav to Overview and restructure overview page

### DIFF
--- a/_articles/ai/overview.md
+++ b/_articles/ai/overview.md
@@ -10,14 +10,18 @@ description: Overview of Dynamic Web TWAIN and AI.
 
 # AI Overview
 
-AI can answer questions related to Dynamic Web TWAIN and write codes directly. You can utilize AI in several ways.
+AI can answer questions about Dynamic Web TWAIN and write code directly. You can use AI in several ways.
 
-## How to Use
+## Ask AI
 
-1. Use the "Ask AI" buttton to ask questions about the SDK.
+Use the "Ask AI" button on this documentation site to ask questions about the SDK and get answers based on the documentation.
 
-   ![Ask AI Button](/assets/imgs/ask-ai-button.jpg)
+![Ask AI Button](/assets/imgs/ask-ai-button.jpg)
 
-2. Use the [agent skills](./agent-skills.md) in your AI agent like Claude Code, Codex and Cursor. Skills teach the agent how to include Web TWAIN in your project and use its APIs correctly.
+## Agent Skills
 
-3. Use [llms.txt](/llms.txt) and [llms-full.txt](/llms-full.txt) to provide documentation for large language models (LLMs) and apps that use them.
+Use the [agent skills](./agent-skills.md) in AI agents like Claude Code, Codex, and Cursor. Skills teach the agent how to include Web TWAIN in your project and use its APIs correctly.
+
+## Use with LLMs
+
+Use [llms.txt](/llms.txt) and [llms-full.txt](/llms-full.txt) to provide documentation for large language models (LLMs) and the apps built on them.

--- a/_data/full_tree.yml
+++ b/_data/full_tree.yml
@@ -197,10 +197,9 @@ tree_list:
         path: /info/schedule/Addon.html
       - name: Deprecated
         path: /info/schedule/deprecated.html
-  - name: AI 
+  - name: AI
+    path: /ai/overview.html
     childList:
-      - name: Overview
-        path: /ai/overview.html
       - name: Agent Skills
         path: /ai/agent-skills.html
   - name: Upgrade Instructions


### PR DESCRIPTION
## What

Two changes to the AI documentation section:

### Nav behavior (`_data/full_tree.yml`)
Make the **AI** sidebar entry link directly to the Overview page instead of only expanding. This matches the existing pattern used by **Introduction**, **Hello World**, and **General Usage Guide** — a parent node with both a `path:` and a `childList:`. The now-redundant "Overview" child is removed, so the tree is:

```yaml
- name: AI
  path: /ai/overview.html
  childList:
    - name: Agent Skills
      path: /ai/agent-skills.html
```

### Content (`_articles/ai/overview.md`)
- Replace the `## How to Use` wrapper with one `##` subheading per method: **Ask AI**, **Agent Skills**, **Use with LLMs** — each now has its own anchor.
- Fix typos: "buttton" → "button", "write codes" → "write code", "questions related to" → "questions about".
- Add a short description to each method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)