### PR TITLE
docs(faq): recommend PrintEx over deprecated Print in viewer FAQ

### DIFF
--- a/_articles/faq/print-images-from-viewer.md
+++ b/_articles/faq/print-images-from-viewer.md
@@ -7,12 +7,12 @@ keywords: Dynamic Web TWAIN, Image Viewer, print
 breadcrumbText: Can I print images from the viewer?
 description: Can I print images from the viewer?
 date: 2021-12-09 11:34:50 +0000
-last_modified: 2022-06-10 04:40:03 +0000
+last_modified: 2026-07-29 05:33:17 +0000
 ---
 
 # Image Viewer
 
 ## Can I print images from the viewer?
 
-Yes, you can print the images from the viewer by exporting all image data in the buffer to a new browser window and use the browser's default feature to print images. This can be achieved by using the [Print](/_articles/info/api/WebTwain_IO.md#print){:target="_blank"} API.
-Note: The Print API prints all the images on the viewer, you can use [PrintEx](/_articles/info/api/WebTwain_IO.md#printex){:target="_blank"} to print only selected images.
+Yes, you can print the images from the viewer by exporting the image data in the buffer to a new browser window and use the browser's default feature to print images. This can be achieved by using the [PrintEx](/_articles/info/api/WebTwain_IO.md#printex){:target="_blank"} API, passing the indices of all the images in the buffer to print all of them, or just the selected ones to print a subset.
+Note: [Print](/_articles/info/api/WebTwain_IO.md#print){:target="_blank"} is an older API that also prints all images on the viewer, but it has been deprecated as of release 19.3 in favor of `PrintEx`.


### PR DESCRIPTION
## Summary
- `print-images-from-viewer.md` presented `Print()` as the primary API for printing viewer images, with `PrintEx()` mentioned only as a way to print a subset.
- Per `_articles/info/api/WebTwain_IO.md`, `Print()` has been deprecated as of release 19.3 in favor of `PrintEx()`.
- Swapped the framing: `PrintEx()` (pass all or selected indices) is now presented as the recommended API, with `Print()` noted as the older, deprecated alternative.

Found via a broader FAQ accuracy audit against the API reference docs.

## Test plan
- [x] Confirmed `Print()` deprecation notice and `PrintEx()` signature in `_articles/info/api/WebTwain_IO.md`
- [ ] Docs site build/preview (Jekyll) to confirm the FAQ page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)